### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/jeeeesper/memtally/compare/v0.1.1...v0.1.2) - 2025-06-24
+
+### Other
+
+- Add release-plz CI job
+
 ## [0.1.1](https://github.com/jeeeesper/memtally/compare/v0.1.0...v0.1.1) - 2025-06-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ checksum = "414adb79ae400f95c20f60c851e9ae53d9043ec6e8cc4afa85e20b74874249e5"
 
 [[package]]
 name = "memtally"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "binary-heap-plus",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memtally"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = "A wrapper for some collection types that keeps track of indirectly allocated heap memory"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `memtally`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/jeeeesper/memtally/compare/v0.1.1...v0.1.2) - 2025-06-24

### Other

- Add release-plz CI job
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).